### PR TITLE
chore: add examples for snaildb

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![GitHub License](https://img.shields.io/github/license/Hk669/snaildb?style=flat-square)
 <a href="https://github.com/Hk669/snaildb">![GitHub](https://img.shields.io/github/stars/Hk669/snaildb?style=flat-square)</a>
 <a href="https://docs.rs/snaildb/latest/snaildb/">![Docs](https://img.shields.io/badge/docs-docs.rs-blue?style=flat-square)</a>
+<a href="https://x.com/snaildb_org">![X (Twitter)](https://img.shields.io/badge/follow-@snaildb_org-1da1f2?logo=x&logoColor=white&style=flat-square)</a>
 
 An embedded, persistent key-value store written in Rust.
 
@@ -19,7 +20,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-snaildb = "0.1"
+snaildb = "0.2"
 ```
 
 Or install the binaries from [GitHub Releases](https://github.com/Hk669/snaildb/releases).
@@ -98,13 +99,17 @@ fn store_data() -> Result<()> {
 
 ## Examples
 
-See the [examples directory](./examples) for more detailed usage examples.
+See the [examples directory](./snaildb/examples) for more detailed usage examples. Run them with:
+
+```bash
+cargo run --example <example_name> --package snaildb
+```
 
 ## Configuration
 
 ### Flush Threshold
 
-The flush threshold determines when the in-memory memtable is flushed to disk as an SSTable. Default is 250 MiB.
+The flush threshold determines when the in-memory memtable is flushed to disk as an SSTable. Default is 64 MiB.
 
 ```rust
 let mut db = SnailDb::open("./data")?

--- a/snaildb/examples/README.md
+++ b/snaildb/examples/README.md
@@ -1,0 +1,62 @@
+# Examples
+
+This directory contains example programs demonstrating how to use snaildb.
+
+## Running Examples
+
+You can run any example using Cargo:
+
+```bash
+cargo run --example <example_name> --package snaildb
+```
+
+## Available Examples
+
+### `basic_operations`
+Demonstrates basic database operations:
+- Opening a database
+- Storing key-value pairs with `put()`
+- Retrieving values with `get()`
+- Deleting keys with `delete()`
+
+Run with:
+```bash
+cargo run --example basic_operations --package snaildb
+```
+
+### `string_operations`
+Shows how to work with string values:
+- Storing string values directly (no need to convert to bytes)
+- Retrieving and converting bytes back to strings
+- Using `String::from_utf8_lossy()` for safe conversion
+
+Run with:
+```bash
+cargo run --example string_operations --package snaildb
+```
+
+### `custom_flush_threshold`
+Demonstrates configuring a custom flush threshold:
+- Setting a custom memtable flush threshold
+- Understanding when data gets flushed to disk
+
+Run with:
+```bash
+cargo run --example custom_flush_threshold --package snaildb
+```
+
+### `batch_operations`
+Demonstrates batch operations:
+- Storing multiple key-value pairs in a loop
+- Retrieving multiple values
+- Batch deletions
+- Verifying operations
+
+Run with:
+```bash
+cargo run --example batch_operations --package snaildb
+```
+
+## Note
+
+All examples create a `./data` directory in the current working directory. You may want to clean this up after running examples, or modify the examples to use a temporary directory.

--- a/snaildb/examples/basic_operations.rs
+++ b/snaildb/examples/basic_operations.rs
@@ -1,0 +1,29 @@
+use snaildb::SnailDb;
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    // Open or create a database at a directory
+    let mut db = SnailDb::open("./data")?;
+    
+    // Store a key-value pair
+    db.put("user:1", b"Alice")?;
+    db.put("user:2", b"Bob")?;
+    
+    // Retrieve a value
+    match db.get("user:1")? {
+        Some(value) => println!("Found: {:?}", String::from_utf8_lossy(&value)),
+        None => println!("Key not found"),
+    }
+    
+    // Delete a key
+    db.delete("user:2")?;
+    
+    // Verify deletion
+    match db.get("user:2")? {
+        Some(_) => println!("Key still exists (unexpected)"),
+        None => println!("Key successfully deleted"),
+    }
+    
+    Ok(())
+}
+

--- a/snaildb/examples/batch_operations.rs
+++ b/snaildb/examples/batch_operations.rs
@@ -1,0 +1,50 @@
+use snaildb::SnailDb;
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    let mut db = SnailDb::open("./data")?;
+    
+    println!("Storing multiple key-value pairs...");
+    
+    // Put multiple values
+    for i in 0..10 {
+        let key = format!("key:{}", i);
+        let value = format!("value:{}", i);
+        db.put(&key, value.as_bytes())?;
+        println!("Stored: {} -> {}", key, value);
+    }
+    
+    println!("\nRetrieving all values...");
+    
+    // Retrieve all values
+    for i in 0..10 {
+        let key = format!("key:{}", i);
+        match db.get(&key)? {
+            Some(value) => {
+                let value_str = String::from_utf8_lossy(&value);
+                println!("Retrieved: {} -> {}", key, value_str);
+            }
+            None => println!("Key {} not found", key),
+        }
+    }
+    
+    println!("\nDeleting some keys...");
+    
+    // Delete some keys
+    db.delete("key:5")?;
+    db.delete("key:7")?;
+    println!("Deleted key:5 and key:7");
+    
+    // Verify deletions
+    assert_eq!(db.get("key:5")?, None);
+    assert_eq!(db.get("key:7")?, None);
+    println!("Verified deletions successful");
+    
+    // Verify others still exist
+    assert_eq!(db.get("key:0")?, Some(b"value:0".to_vec()));
+    assert_eq!(db.get("key:9")?, Some(b"value:9".to_vec()));
+    println!("Verified remaining keys still exist");
+    
+    Ok(())
+}
+

--- a/snaildb/examples/custom_flush_threshold.rs
+++ b/snaildb/examples/custom_flush_threshold.rs
@@ -1,0 +1,23 @@
+use snaildb::SnailDb;
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    // Create a database with a custom flush threshold
+    // The memtable will be flushed to disk when it reaches 256 MiB
+    let mut db = SnailDb::open("./data")?
+        .with_flush_threshold(256 * 1024 * 1024); // Flush memtable after 256 MiB
+    
+    // Use the database normally
+    db.put("config:flush_threshold", "256 MiB")?;
+    
+    match db.get("config:flush_threshold")? {
+        Some(value) => {
+            let value_str = String::from_utf8_lossy(&value);
+            println!("Flush threshold configured: {}", value_str);
+        }
+        None => println!("Key not found"),
+    }
+    
+    Ok(())
+}
+

--- a/snaildb/examples/string_operations.rs
+++ b/snaildb/examples/string_operations.rs
@@ -1,0 +1,30 @@
+use snaildb::SnailDb;
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    let mut db = SnailDb::open("./data")?;
+
+    // Store string values directly
+    db.put("name", "snaildb")?;
+    db.put("version", "0.2.0")?;
+    db.put("description", "An embedded, persistent key-value store")?;
+
+    // Retrieve as string
+    if let Some(bytes) = db.get("name")? {
+        let value = String::from_utf8_lossy(&bytes);
+        println!("Name: {}", value);
+    }
+
+    if let Some(bytes) = db.get("version")? {
+        let value = String::from_utf8_lossy(&bytes);
+        println!("Version: {}", value);
+    }
+
+    if let Some(bytes) = db.get("description")? {
+        let value = String::from_utf8_lossy(&bytes);
+        println!("Description: {}", value);
+    }
+
+    Ok(())
+}
+


### PR DESCRIPTION
This pull request adds comprehensive usage examples for `snaildb` and improves the documentation to make it easier for users to get started and understand key configuration options. The main changes include the addition of an `examples` directory with multiple example programs, updates to the `README.md` for clearer instructions, and corrections to configuration details.

**Documentation improvements:**

- Added a badge and link to the official X (Twitter) account in the `README.md` for better project visibility.
- Updated the `README.md` to reference the correct crate version (`0.2`) in the installation instructions.
- Clarified and expanded the usage instructions for running examples, including the correct path and cargo commands in the `README.md`.
- Corrected the default flush threshold documentation from 250 MiB to 64 MiB in the `README.md`.

**Examples and sample code:**

- Added a new `snaildb/examples/README.md` that describes all available examples and how to run them.
- Introduced four example programs demonstrating basic operations, string handling, custom flush thresholds, and batch operations: `basic_operations.rs` [[1]](diffhunk://#diff-93d11df7b3e9e8126b7cc15b3db88df2764d6147941db1494715e5f87671bc88R1-R29) `string_operations.rs` [[2]](diffhunk://#diff-f0368318c32e881d23d68601b901dc51c6826eb4d35c2f385d0d82774962abedR1-R30) `custom_flush_threshold.rs` [[3]](diffhunk://#diff-ae865fca802f3ef7dae56044248ecf5f075f1461c1bd8d6aa178328a6565fe02R1-R23) and `batch_operations.rs` [[4]](diffhunk://#diff-3696dbab4d38960a875985c49f81f5027105703dd2e8557cddfbcd8cc1214477R1-R50).