### PR TITLE
Batching of WAL writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snailctl"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "axum",
  "serde",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "snaildb"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Hk669"]
 license = "Apache-2.0"

--- a/snaildb/src/utils/mod.rs
+++ b/snaildb/src/utils/mod.rs
@@ -1,5 +1,5 @@
 pub mod record;
 pub mod value;
 
-pub use record::{DecodedRecord, RecordKind, read_record, write_record};
+pub use record::{DecodedRecord, RecordKind, read_record, write_record, encode_batch_records};
 pub use value::Value;

--- a/snaildb/src/wal/db_sync.rs
+++ b/snaildb/src/wal/db_sync.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 use std::time::Duration;
 
 /// Configuration constant for flush interval
-pub const FLUSH_INTERVAL_MS: u64 = 50; // 50 ms
+pub const FLUSH_INTERVAL_MS: u64 = 10; // 10 ms
 
 /// Manages the sync/flush state and operations for WAL durability.
 /// 

--- a/snaildb/src/wal/mod.rs
+++ b/snaildb/src/wal/mod.rs
@@ -3,3 +3,4 @@ pub mod enums;
 pub mod db_sync;
 
 pub use wal::Wal;
+pub use db_sync::{FLUSH_INTERVAL_MS, SyncManager};


### PR DESCRIPTION
This pull request introduces several optimizations and refactorings to the Write-Ahead Log (WAL) implementation, focusing on batching record writes to reduce syscall overhead, improving flush/reset handling, and making related utility code more modular and reusable. Additionally, it makes minor configuration and API improvements for better maintainability.

**WAL batching and I/O optimizations:**

* Refactored the WAL worker to batch multiple `WriteRecord` commands into a single buffer and write them in one syscall, reducing I/O overhead and improving performance. The batching loop drains the channel for more records up to a configurable flush interval (`FLUSH_INTERVAL_MS`), which is now set to 10ms for more frequent flushing. [[1]](diffhunk://#diff-991cac5d40f2c843a85fd4a29e327b0e70a115d7ee11422caec414ce8c4e0689R207-R288) [[2]](diffhunk://#diff-6ac0af7fc5ef85e4826c982b626169600a8e918a7c65ca636d35e4204b9f5812L5-R5)
* Added helper functions (`write_batch_if_needed`, `handle_flush`, `handle_reset`) to encapsulate batch writing, flushing, and reset logic, improving code clarity and reducing duplication.

**Record encoding utilities:**

* Extracted record encoding logic into a reusable `encode_record_to_buffer` function, and added a new `encode_batch_records` utility for appending encoded records to a buffer, facilitating batch writes. [[1]](diffhunk://#diff-11c6bbfac075b8e809d1adf1a701e6e91e3d1241677c8b9196a88a85aa7e1ed2L41-R47) [[2]](diffhunk://#diff-11c6bbfac075b8e809d1adf1a701e6e91e3d1241677c8b9196a88a85aa7e1ed2L79-R96) [[3]](diffhunk://#diff-11c6bbfac075b8e809d1adf1a701e6e91e3d1241677c8b9196a88a85aa7e1ed2R252-R264) [[4]](diffhunk://#diff-5cd3ad99fdc56efe50741ece42cc11e04e69864290b7cb583d8202a2f50bb5e6L4-R4)

**API and configuration improvements:**

* Re-exported `FLUSH_INTERVAL_MS` and `SyncManager` from the WAL module for easier access.
* Updated the workspace package version in `Cargo.toml` to `0.2.2`.

**Dependency and import adjustments:**

* Updated imports in `wal.rs` to use the new batch encoding utility and re-exported configuration constants.

These changes collectively improve the efficiency, maintainability, and clarity of the WAL subsystem, especially under high write loads.

**Benchmarks**

`10ms | 241.69K ops/sec | +61.1%`

Closes #21 